### PR TITLE
[DRAFT] Implementing the class feature and human friendly 3-word hash

### DIFF
--- a/db/class.go
+++ b/db/class.go
@@ -1,0 +1,17 @@
+package db
+
+// Class is a struct representation of a class document.
+// It provides functions for converting the struct
+// to firebase-digestible types.
+type Class struct {
+	Thumbnail           int64 		`firestore:"thumbnail" json:"thumbnail"`
+	Name       			string   	`firestore:"name" json:"name"`
+	Creator 			string   	`firestore:"creator" json:"creator"`
+	Instructors         []string   	`firestore:"instructors" json:"instructors"`
+	Members          	[]string 	`firestore:"members" json:"members"`
+	Programs           	[]string   	`json:"programs"`
+	CID					string 		`json:"cid"`
+	WID					string 		`json:"wid"`
+}
+
+

--- a/db/classManagement.go
+++ b/db/classManagement.go
@@ -1,0 +1,305 @@
+package db
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"../tools/requests"
+)
+
+// HandleCreateClass is the handler for creating a new class.
+// It takes the UID of the creator, the name of the class, and a thunmbnail id. 
+func (d *DB) HandleCreateClass(w http.ResponseWriter, r *http.Request) {
+	
+	var (
+		err error
+	)
+
+	//create an anonymous structure to handle requests
+	req := struct {
+		UID 		string  	`json:"uid"`
+		Name 		string		`json:"name"`
+		Thumbnail 	int64 		`json:"thumbnail"`
+	}{}
+	//read JSON from request body
+	if err = requests.BodyTo(r, &req); err != nil {
+		http.Error(w, "Error occurred in reading body.", http.StatusInternalServerError)
+		return
+	}
+
+	if req.UID == "" {
+		http.Error(w, "Error occurred in reading UID.", http.StatusInternalServerError)
+		return
+	}
+	
+	if req.Name == "" {
+		http.Error(w, "Error occurred in reading Name.", http.StatusInternalServerError)
+		return
+	}
+
+	if req.Thumbnail < 0 || req.Thumbnail >= 50 {
+		http.Error(w, "Bad thumbnail provided, Exiting", http.StatusInternalServerError)
+		return
+	}
+
+	
+
+	// structure for class info
+	class := Class{
+		Thumbnail: req.Thumbnail, 
+		Name: req.Name, 
+		Creator: req.UID, 
+		Instructors: []string{req.UID},
+		Members: []string{},
+		Programs: []string{},
+	}	
+
+	
+
+	// create the class
+	cid, err := d.CreateClass(r.Context(), &class)
+	if err != nil {
+		http.Error(w, "Error updating class in Firebase", http.StatusInternalServerError)
+		return
+	}
+
+	//create an wid for this class
+	wid, err := d.MakeAlias(r.Context(), cid, ClassesAliasPath)
+
+	//Update class info 
+	// create the class
+	err = d.UpdateClassWID(r.Context(), cid, wid)
+
+	//add this class to the user's "Classes" list
+	err = d.AddClassToUser(r.Context(), req.UID, cid)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// read the class document just created 
+	c, err := d.GetClass(r.Context(), cid)
+	if err != nil || c == nil {
+		http.Error(w, "Class does not exist", http.StatusNotFound)
+		return
+	}
+	//return the class struct in the response
+	if resp, err := json.Marshal(c); err != nil {
+		http.Error(w, "Failed to marshal response", http.StatusInternalServerError)
+	} else {
+		w.Write(resp)
+	}
+}
+
+// HandleGetClass takes the UID (either of a member or an instructor) 
+// and a CID (wid) as a JSON, and returns an object representing the class. 
+// If the given UID is not a member or an instructor, error is returned
+func (d *DB) HandleGetClass(w http.ResponseWriter, r *http.Request) {
+	
+	var err error
+
+	//create an anonymous structure to handle requests
+	req := struct {
+		UID 		string  	`json:"uid"`
+		WID 		string		`json:"cid"`
+	}{}
+
+	//read JSON from request body
+	if err = requests.BodyTo(r, &req); err != nil {
+		http.Error(w, "Error occurred in reading body", http.StatusInternalServerError)
+		return
+	}
+	if req.UID == "" {
+		http.Error(w, "Error occurred in reading uid", http.StatusInternalServerError)
+		return
+	}
+	if req.WID == "" {
+		http.Error(w, "Error occurred in reading cid", http.StatusInternalServerError)
+		return
+	}
+
+	cid, err := d.GetUIDFromWID(r.Context(), req.WID, ClassesAliasPath)
+
+	// get the class as a struct (pointer)
+	c, err := d.GetClass(r.Context(), cid)
+
+	// check for error
+	if err != nil || c == nil {
+		http.Error(w, "Failed to get class (class does not exist or failed to unmarshal data)", http.StatusNotFound)
+		return
+	}
+
+	//check if the uid exists in the members list or instructor list
+	var is_in bool = false;
+
+	for _, m := range c.Members {
+		if m == req.UID {
+			is_in = true
+			break
+		}
+	}
+
+	for _, i := range c.Instructors{
+		if i == req.UID {
+			is_in = true
+			break
+		}
+	}
+	
+	// if UID was not in class, return error
+	if !is_in {
+		http.Error(w, "Couldn't find user in class", http.StatusInternalServerError)
+		return
+	}
+
+	// otherwise, convert the class struct into JSON and send it back
+	if resp, err := json.Marshal(c); err != nil {
+		http.Error(w, "Failed to marshal response.", http.StatusInternalServerError)
+	} else {
+		w.Write(resp)
+	}
+}
+
+// HandleJoinClass takes a UID and cid(wid) as a JSON, and attempts to 
+// add the UID to the class given by cid. The updated struct of the class is returned as a 
+// JSON
+
+func (d *DB) HandleJoinClass(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	//create an anonymous structure to handle requests
+	req := struct {
+		UID 		string  	`json:"uid"`
+		WID 		string		`json:"cid"`
+	}{}
+
+	//read JSON from request body
+	if err = requests.BodyTo(r, &req); err != nil {
+		http.Error(w, "Error occurred in reading body", http.StatusInternalServerError)
+		return
+	}
+	if req.UID == "" {
+		http.Error(w, "Error occurred in reading UID", http.StatusInternalServerError)
+		return   
+	}
+	if req.WID == "" {
+		http.Error(w, "error occurred in reading WID", http.StatusInternalServerError)
+		return
+	}
+
+	//TODO
+	cid, err := d.GetUIDFromWID(r.Context(), req.WID, ClassesAliasPath)
+
+	// get the class as a struct
+	c, err := d.GetClass(r.Context(), cid)
+	// check for error
+	if err != nil || c == nil {
+		http.Error(w, "Class does not exist.", http.StatusNotFound)
+		return
+	}
+
+	//check if the user exists
+	_, err = d.GetUser(r.Context(), req.UID)
+	if err != nil {
+		http.Error(w, "User does not exist.", http.StatusNotFound)
+		return
+	}
+
+	//add user to the class
+	err = d.AddUserToClass(r.Context(), req.UID, cid)
+	if err != nil {
+		http.Error(w, "Failed to add user to class", http.StatusNotFound)
+		return
+	}
+
+	//add this class to the user's "Classes" list
+	err = d.AddClassToUser(r.Context(), req.UID, cid)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// get the updated class as a struct
+	c, err = d.GetClass(r.Context(), cid)
+	if err != nil || c == nil {
+		http.Error(w, "Class does not exist.", http.StatusNotFound)
+		return
+	}
+
+	// return the updated class struct as JSON
+	if resp, err := json.Marshal(c); err != nil {
+		http.Error(w, "Failed to marshal response", http.StatusInternalServerError)
+	} else {
+		w.Write(resp)
+	}
+
+}
+
+
+func (d *DB) HandleLeaveClass(w http.ResponseWriter, r *http.Request) {
+
+	var (
+		err error
+	)
+
+	//create an anonymous structure to handle requests
+	req := struct {
+		UID 		string  	`json:"uid"`
+		CID 		string		`json:"cid"`
+	}{}
+
+	//read JSON from request body
+	if err = requests.BodyTo(r, &req); err != nil {
+		http.Error(w, "error occurred in reading body.", http.StatusInternalServerError)
+		return
+	}
+	if req.UID == "" {
+		http.Error(w, "error occurred in reading body.", http.StatusInternalServerError)
+		return
+	}
+	if req.CID == "" {
+		http.Error(w, "error occurred in reading body.", http.StatusInternalServerError)
+		return
+	}
+
+	// get the class as a struct
+	c, err := d.GetClass(r.Context(), req.CID)
+
+	// check for error
+	if err != nil || c == nil {
+		http.Error(w, "class does not exist.", http.StatusNotFound)
+		return
+	}
+
+	//check if the user exists
+	_, err = d.GetUser(r.Context(), req.UID)
+	if err != nil {
+		http.Error(w, "user does not exist.", http.StatusNotFound)
+		return
+	}
+
+	//remove user from the class
+	err = d.RemoveUserFromClass(r.Context(), req.UID, req.CID)
+	if err != nil {
+		http.Error(w, "Failed to add user", http.StatusNotFound)
+		return
+	}
+
+	//remove cid from user list
+	err = d.RemoveClassFromUser(r.Context(), req.UID, req.CID)
+	if err != nil {
+		http.Error(w, "Failed to add user", http.StatusNotFound)
+		return
+	}
+
+	// return the latest state of the user
+	u, err := d.GetUser(r.Context(), req.UID)
+
+	if resp, err := json.Marshal(u); err != nil {
+		http.Error(w, "failed to marshal response.", http.StatusInternalServerError)
+	} else {
+		w.Write(resp)
+	}
+
+}

--- a/db/classManagement.go
+++ b/db/classManagement.go
@@ -37,7 +37,7 @@ func (d *DB) HandleCreateClass(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if req.Thumbnail < 0 || req.Thumbnail >= 50 {
+	if req.Thumbnail < 0 || req.Thumbnail >= ThumbnailCount  {
 		http.Error(w, "Bad thumbnail provided, Exiting", http.StatusInternalServerError)
 		return
 	}
@@ -130,7 +130,7 @@ func (d *DB) HandleGetClass(w http.ResponseWriter, r *http.Request) {
 	}
 
 	//check if the uid exists in the members list or instructor list
-	var is_in bool = false;
+	is_in := false;
 
 	for _, m := range c.Members {
 		if m == req.UID {

--- a/db/constants.go
+++ b/db/constants.go
@@ -32,6 +32,18 @@ const (
 	// UsersPath describes the path to the user management
 	// endpoint
 	UsersPath = "users"
+	
+	// ClassesPath describes the path to the classes
+	// management endpoint.
+	ClassesPath = "classes"
+
+	// ProgramsAliasPath describes the path to the collection with 3 word id => hash mapping for programs
+	ProgramsAliasPath = "programs_alias"
+
+	// ClassesAliasPath describes the path to the collection with 3 word id => hash mapping for classes
+	ClassesAliasPath = "classes_alias"
+
+	
 )
 
 // LanguageName acquires the name for the language desecribed

--- a/db/db.go
+++ b/db/db.go
@@ -269,8 +269,8 @@ func (d *DB) GetClass(ctx context.Context, cid string) (*Class, error) {
 	return c, err
 }
 
-// MakeAlias takes an id (usually pid or cid), generates a 3 word id(wid), and 
-// stores it in Firebase. The generated wid is returned as a string, with words comma seperated
+// MakeAlias takes an id (usually pid or cid), allocates a 3 word id(wid), and 
+// stores it in Firebase. The generated wid is a string, with words comma seperated
 func (d *DB) MakeAlias(ctx context.Context, uid string, path string) (string, error) {
 
 	// convert uid into a 36 bit hash

--- a/db/programManagement.go
+++ b/db/programManagement.go
@@ -114,7 +114,7 @@ func (d *DB) HandleInitializeProgram(w http.ResponseWriter, r *http.Request) {
 	ctx := context.WithValue(r.Context(), "getProgram", p)
 	d.HandleGetProgram(w, r.WithContext(ctx))
 }
-
+ 
 /**
  * updateProgramData
  * Body:

--- a/db/userManagement.go
+++ b/db/userManagement.go
@@ -73,6 +73,8 @@ func (d *DB) HandleGetUser(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	
+
 	// convert to JSON.
 	if userJSON, err = json.Marshal(resp); err != nil {
 		http.Error(w, "error occurred in writing response.", http.StatusInternalServerError)

--- a/server.go
+++ b/server.go
@@ -45,6 +45,13 @@ func main() {
 	router.HandleFunc("/program/create", d.HandleInitializeProgram)
 	router.HandleFunc("/program/delete", d.HandleDeleteProgram)
 
+	//class management
+	router.HandleFunc("/class/create", d.HandleCreateClass)
+	router.HandleFunc("/class/get", d.HandleGetClass)
+	router.HandleFunc("/class/join", d.HandleJoinClass)
+	router.HandleFunc("/class/leave", d.HandleLeaveClass)
+	
+
 	// fallback route
 	router.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "", http.StatusNotFound)

--- a/server_test.go
+++ b/server_test.go
@@ -25,16 +25,17 @@ type Response struct {
 func TestRigDB(t *testing.T) {
 
 	var (
-		d   *db.DB // stores instance of connection with database
+		d   *db.DB 		// stores instance of connection with database
 		err error
-		res Response // structure to store response fron database
+		res Response 	// structure to store response fron database
+		res_student Response 	// structure to store response fron database
+		class_id string
 	)
 
 	t.Logf("Testing initialization of database...")
 
 	// Test opening connection with database
 	t.Run("Open connection with database", func(t *testing.T) {
-
 		if d, err = db.OpenFromEnv(context.Background()); err != nil {
 			t.Fatal("failed to open DB client")
 		}
@@ -42,7 +43,6 @@ func TestRigDB(t *testing.T) {
 
 	t.Logf("Testing creating new user...")
 
-	// Test creating a new user
 	t.Run("Create new user", func(t *testing.T) {
 
 		req, err := http.NewRequest("POST", "/user/create", nil)
@@ -77,7 +77,6 @@ func TestRigDB(t *testing.T) {
 
 	t.Logf("Testing deletion of program from user...")
 
-	// Test deleting a program from a user
 	t.Run("Delete program", func(t *testing.T) {
 
 		req, err := http.NewRequest("DELETE", "/program/delete", nil)
@@ -88,9 +87,6 @@ func TestRigDB(t *testing.T) {
 
 		// build query
 		p := req.URL.Query()
-
-		//fmt.Printf("UID: %s\n", res.UserData.UID)
-		//fmt.Printf("Program: %s\n", res.UserData.Programs[0])
 
 		p.Add("userId", res.UserData.UID)
 		p.Add("programId", res.UserData.Programs[0])
@@ -109,10 +105,10 @@ func TestRigDB(t *testing.T) {
 
 	t.Logf("Testing creating program for user...")
 
-	// Test creating a program from a user
 	t.Run("Create program", func(t *testing.T) {
 
-		// create JSON for a new program
+		t.Logf("Building query")
+		// create JSON for a new program 
 		pr := struct {
 			Code        string
 			DateCreated string
@@ -135,8 +131,6 @@ func TestRigDB(t *testing.T) {
 			t.Fatal("Failed to create JSON")
 		}
 
-		//fmt.Printf("%s", pro)
-
 		req, err := http.NewRequest("POST", "/program/create", bytes.NewBuffer(pro))
 		req.Header.Set("Content-Type", "application/json")
 
@@ -147,8 +141,176 @@ func TestRigDB(t *testing.T) {
 		rr := httptest.NewRecorder()
 		handler := http.HandlerFunc(d.HandleInitializeProgram)
 
+		t.Logf("Making call...")
 		handler.ServeHTTP(rr, req)
 
+		if status := rr.Code; status != http.StatusOK {
+			t.Fatal("Create program failed")
+		}
+
+	})
+
+	t.Logf("Testing getting user...")
+
+	t.Run("Get user", func(t *testing.T) {
+
+		t.Logf("Building query")
+
+		req, err := http.NewRequest("GET", "/user/get", nil)
+
+		if err != nil {
+			t.Fatal("Failed to create http request")
+		}
+
+		// build query
+		p := req.URL.Query()
+
+		//p.Add("userId", res.UserData.UID)
+		//p.Add("includePrograms", res.UserData.Programs[0])
+		t.Log(res.UserData.UID)
+		p.Add("id", res.UserData.UID)
+		p.Add("programs", "true")
+		req.URL.RawQuery = p.Encode()
+
+		rr := httptest.NewRecorder()
+		handler := http.HandlerFunc(d.HandleGetUser)
+
+		// struct to recieve response 
+		resp := struct {
+			UserData *db.User     `json:"userData"`
+			Programs []db.Program `json:"programs"`
+		}{}
+
+		handler.ServeHTTP(rr, req)
+		t.Log(rr.Body)
+		//get raw data returned
+		//unmarshall json
+		j, err := ioutil.ReadAll(rr.Result().Body)
+		if err != nil {
+			t.Fatal("Failed to read response")
+		}
+
+		json.Unmarshal([]byte(j), resp)
+
+		//TODO check if correct programs are made
+		//t.Logf(resp.Programs[0].Name)
+		
+		if status := rr.Code; status != http.StatusOK {
+			t.Fatal("Get user failed")
+		}
+		
+	})
+
+	// Test creating a class from a user
+	t.Run("Create Class", func(t *testing.T){
+
+		// create JSON for a new program 
+		pr := struct {
+			Uid 		string
+			Name 		string
+			Thumbnail	int
+		}{
+			res.UserData.UID,
+			"TestClass",
+			1,
+		}
+
+		pro, err := json.Marshal(&pr) 
+
+		if err != nil {
+			t.Fatal("Failed to create JSON")
+		}
+
+		//fmt.Printf("%s", pro)
+
+		req, err := http.NewRequest("POST", "/class/create", bytes.NewBuffer(pro))
+		req.Header.Set("Content-Type", "application/json")
+
+		if err != nil {
+			t.Fatal("Failed to test create program")
+		}
+
+		rr := httptest.NewRecorder()
+		handler := http.HandlerFunc(d.HandleCreateClass)
+
+		handler.ServeHTTP(rr, req)
+
+		var class db.Class
+
+		t.Log(rr.Body)
+
+		j, err := ioutil.ReadAll(rr.Result().Body)
+		if err != nil {
+			t.Fatal("Failed to read response")
+		}
+
+		json.Unmarshal([]byte(j), &class)
+		class_id = class.WID
+		
+
+		if status := rr.Code; status != http.StatusOK {
+			t.Fatal("Create program failed")
+		}
+
+	})
+
+	// Create another student to join the class
+	t.Run("Create new student", func(t *testing.T) {
+		req, err := http.NewRequest("POST", "/user/create", nil)
+		if err != nil {
+			t.Fatal("Failed to create http request")
+		}
+		rr := httptest.NewRecorder()
+		handler := http.HandlerFunc(d.HandleInitializeUser)
+
+		handler.ServeHTTP(rr, req)
+
+		if status := rr.Code; status != http.StatusOK {
+			t.Fatal("Failed to create user")
+		}
+
+		defer rr.Result().Body.Close()
+
+		j, err := ioutil.ReadAll(rr.Result().Body)
+		if err != nil {
+			t.Fatal("Failed to read response")
+		}
+
+		json.Unmarshal([]byte(j), &res_student)
+	})
+
+	// Test adding a user to class
+	t.Run("Join Class", func(t *testing.T){
+
+		// create JSON for a new program 
+		pr := struct {
+			Uid 		string
+			Cid			string
+		}{
+			res.UserData.UID,
+			class_id,
+		}
+
+		pro, err := json.Marshal(&pr) 
+
+		if err != nil {
+			t.Fatal("Failed to create JSON")
+		}
+
+		//fmt.Printf("%s", pro)
+
+		req, err := http.NewRequest("POST", "/class/join", bytes.NewBuffer(pro))
+		req.Header.Set("Content-Type", "application/json")
+
+		if err != nil {
+			t.Fatal("Failed to test create program")
+		}
+		
+		rr := httptest.NewRecorder()
+		handler := http.HandlerFunc(d.HandleJoinClass)
+
+		handler.ServeHTTP(rr, req)
+		t.Log(rr.Body)
 		if status := rr.Code; status != http.StatusOK {
 			t.Fatal("Create program failed")
 		}


### PR DESCRIPTION
Requesting review of a draft which implements the following features:
- Class struct (in `class.go`)
- Handlers for requests related to classes (`classManagement.go`)
- Additional functions in `db.go` to communicate class-related  information with Firebase 
- Generation of a 3-word hash (`tools/tinycrypt`) for a given pid/cid, which will be stored in Firebase.

Some notes:
- In `tinycrypt`, the only function used is `GenerateWord36()` Other functions are not used, but are kept as it _might_ be needed in the future in case hash collision becomes a problem, although it is unlikely since we have 68 billion slots.
-  ~~`MakeAlias()` in `db.go` has a known bug, where the 36 bit hash is used to check if a hash is already taken, when it is supposed to use the 3-word hash (since the document keys stored in Firebase use the 3-word hash)~~ Has been fixed.