### PR TITLE
Accurate handling of mostRecentProgram and correct GetProgram response.

### DIFF
--- a/db/user.go
+++ b/db/user.go
@@ -19,7 +19,7 @@ import (
 type User struct {
 	Classes           []string `firestore:"classes" json:"classes"`
 	DisplayName       string   `firestore:"displayName" json:"displayName"`
-	MostRecentProgram int64    `firestore:"mostRecentProgram" json:"mostRecentProgram"`
+	MostRecentProgram string   `firestore:"mostRecentProgram" json:"mostRecentProgram"`
 	PhotoName         string   `firestore:"photoName" json:"photoName"`
 	Programs          []string `firestore:"programs" json:"programs"`
 	UID               string   `json:"uid"`
@@ -52,9 +52,12 @@ func (u *User) ToFirestoreUpdate() []firestore.Update {
 // Returns: Status 200 with marshalled User and programs.
 func (d *DB) GetUser(c echo.Context) error {
 	resp := struct {
-		UserData User      `json:"userData"`
-		Programs []Program `json:"programs"`
-	}{}
+		UserData User               `json:"userData"`
+		Programs map[string]Program `json:"programs"`
+	}{
+		UserData: User{},
+		Programs: make(map[string]Program),
+	}
 
 	// get user
 	uid := c.QueryParam("uid")
@@ -97,7 +100,7 @@ func (d *DB) GetUser(c echo.Context) error {
 				return c.String(http.StatusInternalServerError, errors.Wrap(progTXErr, "failed to get user's programs").Error())
 			}
 
-			resp.Programs = append(resp.Programs, currentProg)
+			resp.Programs[p] = currentProg
 		}
 	}
 

--- a/db/user_test.go
+++ b/db/user_test.go
@@ -15,29 +15,29 @@ import (
 
 func TestUserToFirestoreUpdate(t *testing.T) {
 	t.Run("MostRecentProgram", func(t *testing.T) {
-		u := User{MostRecentProgram: 3}
+		u := User{MostRecentProgram: "someHash"}
 		update := u.ToFirestoreUpdate()
 		assert.Len(t, update, 1)
-		assert.Equal(t, update[0].Value, int64(3))
+		assert.Equal(t, "someHash", update[0].Value)
 	})
 	t.Run("DisplayName", func(t *testing.T) {
 		u := User{DisplayName: "test"}
 		update := u.ToFirestoreUpdate()
 		assert.Len(t, update, 2)
-		assert.Equal(t, update[0].Path, "mostRecentProgram")
-		assert.Equal(t, update[1].Value, "test")
+		assert.Equal(t, "mostRecentProgram", update[0].Path)
+		assert.Equal(t, "test", update[1].Value)
 	})
 	t.Run("PhotoName", func(t *testing.T) {
 		u := User{PhotoName: "icecream"}
 		update := u.ToFirestoreUpdate()
 		assert.Len(t, update, 2)
-		assert.Equal(t, update[1].Value, "icecream")
+		assert.Equal(t, "icecream", update[1].Value)
 	})
 	t.Run("Programs", func(t *testing.T) {
 		u := User{Programs: []string{"hash0", "hash1"}}
 		update := u.ToFirestoreUpdate()
 		assert.Len(t, update, 2)
-		assert.Equal(t, update[1].Path, "programs")
+		assert.Equal(t, "programs", update[1].Path)
 		// TODO: value cannot be easily verified.
 	})
 }


### PR DESCRIPTION
This PR corrects our response of GetProgram. Previously, it responded with a User object and a slice of Program objects. This led to undefined behavior on the frontend. To account for this, the GetProgram handler will now respond with a JSON object matching the signature:

```go
struct {
	UserData User               `json:"userData"`
	Programs map[string]Program `json:"programs"`
}
```

Another consequence of this decision that was discovered was our handling of the `mostRecentProgram` field. We previously treated it as an `int64`, or `Number`, but following some review of the JavaScript codebase, we found it was a string containing the ID of the latest program. This was surprisingly hard to find, as the frontend would work with **both backends**, since it would use the `mostRecentProgram` field to index into the `programs` part of the response. That is, whether it was an integer or a string didn't matter as long as it was consistent.

In any case, I fixed both these problems. I also updated the tests to reflect this, along with a few small changes in `TestUserToFirestoreUpdate` to match the assertion signature `func assert.Equal(t assert.TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) bool`.