### PR TITLE
Usability extensions to DB#GetClass

### DIFF
--- a/db/class.go
+++ b/db/class.go
@@ -197,7 +197,7 @@ func (d *DB) GetClass(c echo.Context) error {
 		return c.String(http.StatusInternalServerError, errors.Wrap(err, "failed to read request body").Error())
 	}
 	if req.UID == "" || req.CID == "" {
-		return c.String(http.StatusBadRequest, "uid and wid fields are both required")
+		return c.String(http.StatusBadRequest, "uid and cid fields are both required")
 	}
 	uid := req.UID
 	cid := req.CID

--- a/db/class.go
+++ b/db/class.go
@@ -188,7 +188,7 @@ func (d *DB) GetClass(c echo.Context) error {
 		res struct {
 			*Class
 			ProgramData []Program `json:"programData"`
-			UserData []User `json:"userData"`
+			UserData    []User    `json:"userData"`
 		}
 		err error
 	)

--- a/db/class.go
+++ b/db/class.go
@@ -180,29 +180,28 @@ func (d *DB) CreateClass(c echo.Context) error {
 // and a CID (wid) as a JSON, and returns an object representing the class.
 // If the given UID is not a member or an instructor, error is returned
 func (d *DB) GetClass(c echo.Context) error {
-	var req struct {
-		UID string `json:"uid"`
-		WID string `json:"wid"`
-	}
+	var (
+		req struct {
+			UID string `json:"uid"`
+			CID string `json:"cid"`
+		}
+		res struct {
+			*Class
+			ProgramData []Program `json:"programData"`
+		}
+		err error
+	)
+
 	if err := httpext.RequestBodyTo(c.Request(), &req); err != nil {
 		return c.String(http.StatusInternalServerError, errors.Wrap(err, "failed to read request body").Error())
 	}
-	if req.UID == "" || req.WID == "" {
+	if req.UID == "" || req.CID == "" {
 		return c.String(http.StatusBadRequest, "uid and wid fields are both required")
 	}
 	uid := req.UID
-	wid := req.WID
-
-	cid, err := d.GetUIDFromWID(c.Request().Context(), wid, classesAliasPath)
-	if err != nil {
-		return c.String(http.StatusInternalServerError, fmt.Sprintf("failed to get class: %s", err))
-	}
+	cid := req.CID
 
 	// get the class as a struct (pointer)
-	var res struct {
-		*Class
-		ProgramData []Program `json:"programData"`
-	}
 	res.Class, err = d.loadClass(c.Request().Context(), cid)
 	if err != nil || res.Class == nil {
 		return c.String(http.StatusInternalServerError, fmt.Sprintf("failed to get class: %s", err))

--- a/db/class.go
+++ b/db/class.go
@@ -187,8 +187,8 @@ func (d *DB) GetClass(c echo.Context) error {
 		}
 		res struct {
 			*Class
-			ProgramData []Program `json:"programData"`
-			UserData    []User    `json:"userData"`
+			ProgramData []Program       `json:"programData"`
+			UserData    map[string]User `json:"userData"`
 		}
 		err error
 	)
@@ -258,7 +258,7 @@ func (d *DB) GetClass(c echo.Context) error {
 				continue
 			}
 
-			res.UserData = append(res.UserData, tmpUser)
+			res.UserData[uid] = tmpUser
 		}
 	}
 


### PR DESCRIPTION
This PR provides extensions to `DB#GetClass`, allowing classes to be retrieved by their Class ID (not WID). It also adds a query parameter, `userData`, to allow **teachers** of a class to retrieve the userData of their students in a map of their UID to their user data.