### PR TITLE
CLI QOL; docs update

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,51 +6,64 @@ Hey there! This is the repo for the Go Backend for the Teach LA editor. If you'r
 
 # Quickstart
 
+To run the backend locally, you can download the latest build for your system from the
+[releases page](https://github.com/uclaacm/teach-la-go-backend/releases/latest). After
+doing so, follow along with the guide below!
+
 ```sh
-go get github.com/uclaacm/teach-la-go-backend
+$ # run the server
+$ ./tlabe -h
+NAME:
+   Teach LA Go Backend - tlabe [options]
 
-cd $GOPATH/src/github.com/uclaacm/teach-la-go-backend
-# add a remote here if you aren't going to use ours
+USAGE:
+   tlabe [global options] [arguments...]
 
-go get -d ./...
-go build
+VERSION:
+   1.0.0
 
-# source your credentials or create your own
+DESCRIPTION:
+   Teach LA's editor backend.
 
-./teach-la-go-backend
+GLOBAL OPTIONS:
+   --dotenv value, -e value  Specify a path to a dotenv file to specify credentials (default: ".env")
+   --json value, -j value    Specify a path to a JSON file to specify credentials
+   --verbose, -v             Change the log level used by echo's logger middleware (default: false)
+   --port value, -p value    Change the port number (default: "8081")
+   --help, -h                Show help (default: false)
+   --version, -V             Print the version and exit (default: false)
+
+$ ./tlabe -j credentials.json
+⇨ http server started on [::]:8081
+
+$ # from here, you can start up the frontend using your own backend!
 ```
-
-For formatting, we use `gofmt`. For linting, we use `golint` and `golangci-lint`.
 
 # Developer Setup
 
 Here's what you need and how to **build** the project:
 * [git](https://git-scm.com/)
-* [Go](https://golang.org/)
+* [go](https://golang.org/)
+* [make](https://www.gnu.org/software/make/manual/make.html) (optional)
+
+Here's what you need to get your code PR-ready and **contribute** to the project:
+* For formatting, we use `gofmt`. This is included with your installation of [go](https://golang.org/)
+* For linting, we use [`golangci-lint`](https://github.com/golangci/golangci-lint).
 
 ```sh
-export TLAPATH=${GOPATH}/src/github.com/uclaacm/teach-la-go-backend
-
-git clone git@github.com:uclaacm/teach-la-go-backend.git $TLAPATH
-# alternatively, using HTTPS:
-# git clone https://github.com/uclaacm/teach-la-go-backend.git
-
-cd $TLAPATH
-
-# go get dependencies
-go get -d ./...
-# Note: ./... unrolls the current directory.
+git clone https://github.com/uclaacm/teach-la-go-backend.git
+cd teach-la-go-backend
 
 # build the server for your platform
 make
-# ...or build it for all platforms
+# ...or build it for all platforms with the below command:
 # make all
 
 # run the server
 ./bin/tlabe --help
 ```
 
-If you try running the server at this point (with `./teach-la-go-backend`), the program will crash with a message complaining that a DB client could not be opened. To be precise, it will complain with:
+If you try running the server at this point (with `./bin/tlabe`), the program will crash with a message complaining that a DB client could not be opened. To be precise, it will complain with:
 
 ```json
 {
@@ -65,19 +78,17 @@ If you try running the server at this point (with `./teach-la-go-backend`), the 
 
 To **run** the project for live development - not just build it - one needs to be able to interact with the TeachLA Firebase through service account credentials (usually a single JSON file). These can be obtained during a TeachLA dev team meeting, or by messaging the #go-backend channel on the TLA Slack.
 
-**You must change the file extension to `.env` so our `.gitignore` will prevent it from being accidentally uploaded to the public repo**. Once you have done so, simply enter the file, surround the json with single quotes (`'`), and prepend `export TLACFG=` to the first file. It should look something like:
+Once you have acquired a copy of `credentials.json` or otherwise, you can specify the credentials file location:
 
 ```sh
-export TLACFG='{
-    // ...
-}'
+./tlabe -j credentials.json
 ```
 
 You can now run the server you built!
 
 ## Testing
 
-Development is largely test-driven. Any code you contribute should have tests to go with it. Tests should be placed in another file in the same directory with the naming convention `my_file_name_test.go`.
+Development is test-focused. Any code you contribute should have tests to go with it. Tests should be placed in another file in the same directory with the naming convention `my_file_name_test.go`.
 
 Run tests with the following commands:
 
@@ -94,13 +105,7 @@ go test -run TestNameHere
 
 With this, you can build, test, and run the actual backend. If you'd like to get working, you can stop reading here. Otherwise, you can scan through some of the FAQ below.
 
-## Go FAQ
-
-Go is an new language to a great many people. Hopefully the questions you have might be answered below:
-
-### Q: Why even use Go?
-
-Go is a modern, well-abstracted language for writing performant backends and web applications. It has un*paralleled* support for parallelism out of the box -- so much so that it provides primitive types for concurrency out of the box. It is compiled and garbage-collected. All binaries are statically linked.
+## FAQ
 
 ### Q: What are the naming conventions?
 
@@ -114,9 +119,9 @@ Go has some interesting naming conventions. Here's the clif notes:
 
 ### Q: What should my coding style be?
 
-Please, please, **please** use `gofmt` to format your code. Use `golint` (or, better yet, `golangci-lint`) for linting. This makes life easier down the line when others read your code.
+Please, please, **please** use `gofmt` to format your code. Use `golangci-lint` for linting. This makes life easier down the line when others read your code.
 
-Also make sure that you:
+Make sure that you:
 * Comment all exported symbols.
 * Keep names idiomatic.
 
@@ -125,9 +130,3 @@ Also make sure that you:
 We keep our code for handlers in the `db` folder. Each file name describes the class of handlers and associated database types it deals with. For example, `db/program.go` contains the definition for the `Program` type and all handlers that work with it.
 
 If you have any code that extends functionality of an existing package -- say, `pkg` -- place it in another folder `pkgext`. You can take a look at `httpext` for an example of this.
-
-## Didn't answer your question?
-
-If you're on the TeachLA Slack, feel free to @leo with any questions or shoot a message off to the #go-backend channel.
-
-If you're not on our Slack, feel free to shoot an email off to @krashanoff on GitHub.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ DESCRIPTION:
    Teach LA's editor backend.
 
 GLOBAL OPTIONS:
-   --dotenv value, -e value  Specify a path to a dotenv file to specify credentials (default: ".env")
+   --dotenv value, -e value  Specify a path to a dotenv file to specify credentials
    --json value, -j value    Specify a path to a JSON file to specify credentials
    --verbose, -v             Change the log level used by echo's logger middleware (default: false)
    --port value, -p value    Change the port number (default: "8081")

--- a/go.mod
+++ b/go.mod
@@ -25,3 +25,7 @@ require (
 	google.golang.org/genproto v0.0.0-20200724131911-43cab4749ae7 // indirect
 	google.golang.org/grpc v1.30.0
 )
+
+replace (
+  github.com/joho/godotenv => github.com/x1unix/godotenv v1.3.1-0.20200910042738-acd8c1e858a6
+)

--- a/go.sum
+++ b/go.sum
@@ -241,6 +241,8 @@ github.com/valyala/fasttemplate v1.1.0 h1:RZqt0yGBsps8NGvLSGW804QQqCUYYLsaOjTVHy
 github.com/valyala/fasttemplate v1.1.0/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPUpymEIMZ47gx8=
 github.com/valyala/fasttemplate v1.2.0 h1:y3yXRCoDvC2HTtIHvL2cc7Zd+bqA+zqDO6oQzsJO07E=
 github.com/valyala/fasttemplate v1.2.0/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPUpymEIMZ47gx8=
+github.com/x1unix/godotenv v1.3.1-0.20200910042738-acd8c1e858a6 h1:pjYfoc36pzE8YxxhPxiTwVEiPH/Gk6LzJ2qKcpxNgYg=
+github.com/x1unix/godotenv v1.3.1-0.20200910042738-acd8c1e858a6/go.mod h1:/UDsZYR8oO1OfqyyoD+9FWPXZEPIGIA91PcCCSjaH5k=
 github.com/xlab/treeprint v0.0.0-20180616005107-d6fb6747feb6/go.mod h1:ce1O1j6UtZfjr22oyGxGLbauSBp2YVXpARAosm7dHBg=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/server.go
+++ b/server.go
@@ -18,10 +18,6 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-// Default port to serve on, as provided by
-// the operating system.
-var defaultPort = os.Getenv("PORT")
-
 func serve(c *cli.Context) error {
 	e := echo.New()
 	e.HideBanner = true
@@ -44,7 +40,7 @@ func serve(c *cli.Context) error {
 	// - JSON
 	// - .env
 	// - TLACFG
-	jsonPath, dotenvPath := c.String("json"), c.String("env")
+	jsonPath, dotenvPath := c.String("json"), c.String("dotenv")
 	var (
 		d   *db.DB
 		err error
@@ -89,7 +85,12 @@ func serve(c *cli.Context) error {
 	e.GET("/collab/join/:id", d.JoinCollab)
 
 	// check for PORT variable.
-	port := c.String("port")
+	var port string
+	if osPort := os.Getenv("PORT"); osPort != "" {
+		port = osPort
+	} else {
+		port = c.String("port")
+	}
 
 	// server configuration
 	s := &http.Server{
@@ -145,7 +146,7 @@ func main() {
 			&cli.StringFlag{
 				Name:    "port",
 				Aliases: []string{"p"},
-				Value:   defaultPort,
+				Value:   "8081",
 				Usage:   "Change the port number",
 			},
 		},

--- a/server.go
+++ b/server.go
@@ -50,7 +50,7 @@ func serve(c *cli.Context) error {
 		d, err = db.OpenFromJSON(context.Background(), jsonPath)
 	case dotenvPath != "":
 		if err := godotenv.Load(dotenvPath); err != nil {
-			e.Logger.Fatal(errors.Wrap(err, "failed to open .env file"))
+			e.Logger.Error(errors.Wrap(err, "failed to open .env file"))
 		}
 		d, err = db.Open(context.Background(), os.Getenv(db.DefaultEnvVar))
 	default:
@@ -127,7 +127,6 @@ func main() {
 			&cli.StringFlag{
 				Name:     "dotenv",
 				Aliases:  []string{"e"},
-				Value:    ".env",
 				Required: false,
 				Usage:    "Specify a path to a dotenv file to specify credentials",
 			},


### PR DESCRIPTION
Short PR to address a few issues that new members were encountering during onboarding to the backend:
- Multiline string literals in `.env` were improperly parsed. To address this, we have **temporarily** switched our `godotenv` to x1unix's fork. For further reading on the issue and why we are using a fork rather than waiting for the changes to be merged, see joho/godotenv#64 and joho/godotenv#118.
- CLI couldn't load `.env` files because our key names were inconsistent. Addressed this by matching them. See [server.go#L43](https://github.com/uclaacm/teach-la-go-backend/blob/krashanoff/cli-qol/server.go#L43) and [L128](https://github.com/uclaacm/teach-la-go-backend/blob/krashanoff/cli-qol/server.go#L128).
- `.env` options take precedence over CLI options. This should be the default, since most of our developers are simply running `./bin/tlabe`. These changes appear in [server.go#L88:93](https://github.com/uclaacm/teach-la-go-backend/blob/krashanoff/cli-qol/server.go#L88)

Before this PR is ready for review, I plan on also updating our `README.md` to reflect the new project structure.