### PR TITLE
Remove only-new-issues from lint action

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -17,9 +17,6 @@ jobs:
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
           version: v1.29
-
-          # Optional: show only new issues if it's a pull request. The default value is `false`.
-          only-new-issues: true
   lint-fmt:
     name: lint/fmt
     runs-on: ubuntu-latest

--- a/db/class_test.go
+++ b/db/class_test.go
@@ -179,8 +179,8 @@ func TestCreateClass(t *testing.T) {
 	obj.D = ptr
 	require.NoError(t, err)
 
-	CreateTestUser(t, &obj, 0)
-	CreateTestClass(t, &obj, 0, 0)
+	// CreateTestUser(t, &obj, 0)
+	// CreateTestClass(t, &obj, 0, 0)
 
 	// DeleteTestClass(t, &obj, 0)
 	// DeleteTestUser(t, &obj, 0)

--- a/db/class_test.go
+++ b/db/class_test.go
@@ -179,8 +179,8 @@ func TestCreateClass(t *testing.T) {
 	obj.D = ptr
 	require.NoError(t, err)
 
-	// CreateTestUser(t, &obj, 0)
-	// CreateTestClass(t, &obj, 0, 0)
+	CreateTestUser(t, &obj, 0)
+	CreateTestClass(t, &obj, 0, 0)
 
 	// DeleteTestClass(t, &obj, 0)
 	// DeleteTestUser(t, &obj, 0)


### PR DESCRIPTION
Remove this line as all lint issues should be fixed, and it was causing problems with lint errors going undetected. For example, if someone comments out the last call of a function, this introduces a lint error, but it is ignored by the `only-new-issues` parameter.