### PR TITLE
Improve test coverage for constants. Use JSON decoder for httpext.

### DIFF
--- a/db/class_test.go
+++ b/db/class_test.go
@@ -41,10 +41,9 @@ type ReqParam struct {
 }
 
 func CallFunc(t *testing.T, par *ReqParam) ([]byte, func() error) {
-	req, err := http.NewRequest(par.HTTPMethod,
+	req := httptest.NewRequest(par.HTTPMethod,
 		par.Path,
 		par.Body)
-	require.NoError(t, err)
 	rec := httptest.NewRecorder()
 	assert.NotNil(t, req, rec)
 	req.Header.Set("Content-Type", "application/json")
@@ -55,6 +54,7 @@ func CallFunc(t *testing.T, par *ReqParam) ([]byte, func() error) {
 	var b []byte
 	if par.Returns == true {
 		assert.NotEmpty(t, rec.Result().Body)
+		var err error
 		b, err = ioutil.ReadAll(rec.Result().Body)
 		require.NoError(t, err)
 		assert.NoError(t, err)

--- a/db/constants_test.go
+++ b/db/constants_test.go
@@ -6,6 +6,13 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestLangString(t *testing.T) {
+	assert.Equal(t, langString(python), "python")
+	assert.Equal(t, langString(processing), "processing")
+	assert.Equal(t, langString(html), "html")
+	assert.Equal(t, langString(langCount), "DNE")
+}
+
 func TestDefaultProgram(t *testing.T) {
 	p := defaultProgram(langString(python))
 	assert.NotEmpty(t, p)

--- a/httpext/requests.go
+++ b/httpext/requests.go
@@ -2,7 +2,7 @@ package httpext
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 )
 
@@ -12,18 +12,11 @@ import (
 // successfully in the event of partial filling. Empty bodies
 // are also accepted.
 // Returns error on failure.
-// If body is empty, nil is returned, and i is untouched. 
+// If body is empty, nil is returned, and i is untouched.
 func RequestBodyTo(r *http.Request, i interface{}) error {
-	var body = r.Body
-	if body == nil {
+	if err := json.NewDecoder(r.Body).Decode(i); err == io.EOF {
 		return nil
-	} 
-	if bytesBody, err := ioutil.ReadAll(body); err != nil {
-		return err
-	} else if len(bytesBody) == 0 {
-		return nil
-	} else if err := json.Unmarshal(bytesBody, i); err != nil {
+	} else {
 		return err
 	}
-	return nil
 }

--- a/httpext/requests.go
+++ b/httpext/requests.go
@@ -6,8 +6,9 @@ import (
 	"net/http"
 )
 
-// RequestBodyTo reads the request body with ioutil.ReadAll
-// and marshals it into the interface described by i.
+// RequestBodyTo reads the request body and marshals it into
+// the interface described by i. The request body is consumed.
+//
 // As opposed to binding (see echo.Bind), BodyTo will return
 // successfully in the event of partial filling. Empty bodies
 // are also accepted.

--- a/httpext/requests_test.go
+++ b/httpext/requests_test.go
@@ -16,11 +16,29 @@ func TestRequestBodyTo(t *testing.T) {
 		s := ""
 		assert.NoError(t, httpext.RequestBodyTo(r, &s))
 	})
+	t.Run("EmptyBody", func(t *testing.T) {
+		r := httptest.NewRequest(http.MethodGet, "/", strings.NewReader("{}"))
+		var s struct {
+			SomeField bool `json:"someField"`
+		}
+		assert.NoError(t, httpext.RequestBodyTo(r, &s))
+		assert.Zero(t, s.SomeField)
+	})
 	t.Run("ValidBody", func(t *testing.T) {
 		r := httptest.NewRequest(http.MethodGet, "/", strings.NewReader("{\"f\":42}"))
 		var s struct {
 			F int `json:"f"`
 		}
 		assert.NoError(t, httpext.RequestBodyTo(r, &s))
+	})
+	t.Run("PartialFill", func(t *testing.T) {
+		r := httptest.NewRequest(http.MethodGet, "/", strings.NewReader("{\"f\":42}"))
+		var s struct {
+			F     int  `json:"f"`
+			Empty bool `json:"empty"`
+		}
+		assert.NoError(t, httpext.RequestBodyTo(r, &s))
+		assert.Equal(t, 42, s.F)
+		assert.Zero(t, s.Empty)
 	})
 }


### PR DESCRIPTION
This improves our test coverage by a small amount by covering a few lines in `constants.go` and using the `json.Decoder` type rather than unmarshalling our body directly using `ioutil.ReadAll`.

Not sure how this will play with the actions workflow we're using at the moment.