### PR TITLE
remove redundant job

### DIFF
--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -1,20 +1,6 @@
 name: Go Tests
 on: [push]
 jobs:
-  test:
-    name: test
-    runs-on: ubuntu-latest
-    env:
-      TLACFG: ${{ secrets.TLACFG }}
-    steps:
-    - name: Install Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: '1.14'
-    - name: Checkout
-      uses: actions/checkout@v2
-    - name: Passes tests
-      run: go test -v ./...
   test-coverage:
     name: test/coverage
     runs-on: ubuntu-latest


### PR DESCRIPTION
With `test-coverage` we shouldn't need to run tests on their own as well.