### PR TITLE
Add ENABLE_BETA_FEATURES flag

### DIFF
--- a/db/constants.go
+++ b/db/constants.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"math/rand"
+	"os"
 	"time"
 )
 
@@ -45,6 +46,8 @@ const (
 	msgTypeRead  = "READ"
 	msgTypeError = "ERROR"
 )
+
+var EnableBetaFeatures = os.Getenv("ENABLE_BETA_FEATURES")
 
 func langString(langCode int) string {
 	switch langCode {

--- a/handler/user.go
+++ b/handler/user.go
@@ -38,6 +38,11 @@ func GetUser(cc echo.Context) error {
 		c.Logger().Debugf("Failed to load user with uid `%s`: %v", uid, err)
 		return c.String(http.StatusNotFound, "Failed to load user.")
 	}
+
+	if db.EnableBetaFeatures == "true" {
+		user.DeveloperAcc = true
+	}
+
 	resp.UserData = user
 
 	// Get programs, if requested.


### PR DESCRIPTION
This should allow staging/developers to use WIP features (classes) without having to manually enable it. The ENABLE_BETA_FEATURES flag should only be set in the staging env. I'm not sure if there's a cleaner way to implement this.